### PR TITLE
Support parsing of bsc 5.2.1

### DIFF
--- a/identify.js
+++ b/identify.js
@@ -4,7 +4,7 @@ var VERSION = require("./package.json").version,
    ARCH = require("arch")(),
    cp = require("child_process")
 
-var bsc_version_regex = /(\w+)\s+(\d+\.\d+\.\d+)(-[^\s]+)?\s+\(Using\s+OCaml(\d+\.\d+\.\d+)\+BS\s*\)/i
+var bsc_version_regex = /(\w+)\s+(\d+\.\d+\.\d+)(-[^\s]+)?\s+\(\s*Using\s+OCaml:?(\d+\.\d+\.\d+)\+BS\s*\)/i
 
 // NOTE: This doesn't invoke a shell, and thus it doesn't consider $PATH. Intentionally.
 // I'd rather be subject to the vagaries of *just* npm, instead of both npm and the shell.


### PR DESCRIPTION
Adds support for `BuckleScript 5.2.1 ( Using OCaml:4.02.3+BS )`

Previous output is supported too `BuckleScript 5.1.0 (Using OCaml4.02.3+BS )`

Fixes #1 