### PR TITLE
Support bs-platform 7.2.0+

### DIFF
--- a/identify.js
+++ b/identify.js
@@ -6,8 +6,6 @@ var VERSION = require("./package.json").version,
 
 var bsc_version_regex = /(\w+)\s+(\d+\.\d+\.\d+)(-[^\s]+)?\s+\(\s*Using\s+OCaml:?(\d+\.\d+\.\d+)\+BS\s*\)/i
 
-// NOTE: This doesn't invoke a shell, and thus it doesn't consider $PATH. Intentionally.
-// I'd rather be subject to the vagaries of *just* npm, instead of both npm and the shell.
 var bsc_executable = require.resolve("bs-platform/bsc"),
    bsc_version = cp.execFileSync(bsc_executable, ["-version"], { encoding: "utf8" }),
    mr = bsc_version.match(bsc_version_regex)

--- a/identify.js
+++ b/identify.js
@@ -8,7 +8,7 @@ var bsc_version_regex = /(\w+)\s+(\d+\.\d+\.\d+)(-[^\s]+)?\s+\(\s*Using\s+OCaml:
 
 // NOTE: This doesn't invoke a shell, and thus it doesn't consider $PATH. Intentionally.
 // I'd rather be subject to the vagaries of *just* npm, instead of both npm and the shell.
-var bsc_executable = require.resolve("bs-platform/lib/bsc.exe"),
+var bsc_executable = require.resolve("bs-platform/bsc"),
    bsc_version = cp.execFileSync(bsc_executable, ["-version"], { encoding: "utf8" }),
    mr = bsc_version.match(bsc_version_regex)
 


### PR DESCRIPTION
As indicated in the other PR, the location for `bsc.exe` has changed in the latest versions of `bs-platform`. That binary is now placed in a platform-specific directory for each supported platform.

I understand your hesitancy to invoke a shell, but I think that the only possible solution here that is version- and platform- independent may be to link directly to `bs-platform/bsc` script, like I've done in this PR.

I'm happy to squash these two commits if you'd prefer.